### PR TITLE
README formatting and link update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ Please submit bugs there too.
 I started this project back in December 2017 or January 2018, not quite sure anymore, when I was going through the exercises from the [Andrew Ng's machine learning class](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=MachineLearning).
 Also check these playlists [Stanford Machine Learning](https://www.youtube.com/watch?v=UzxYlbK2c7E&list=PLA89DCFA6ADACE599), [Caltech Learning from Data](https://www.youtube.com/watch?v=VeKeFIepJBU&list=PLCA2C1469EA777F9A), [Deep Learning tutorial](http://ufldl.stanford.edu/tutorial/), and there's plenty more from MIT and others.
 
-Since I was really into vscode but unfortunately there was no octave debugger at the time, and since I have a long commute to work, I decided to use that time to develop this adapter.
+Since I was really into vscode but unfortunately there was no Octave debugger at the time, and since I have a long commute to work, I decided to use that time to develop this adapter.
 It kind of was an on and off development, but I would say that about 80% of it was done on the train while commuting to work. I really would like to thank Andrew and all the openclassroom and other similar projects (e.g. OpenCourseWare), and of course the people behind vscode. The best editor of its genre out there.
 
 

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ is equivalent to
 
 * "workingDirectory" is another optional parameter. Octave will switch to this directory before running "program". This allows you to create configurations like:
 
+>
     "program": "foo",
     "sourceFolder": "${workspaceFolder}"
     "workingDirectory": "${workspaceFolder}/A/B/C/"

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ That expression will be evaluated and if successful the variable will be updated
 You can also submit any command you like through the debug console as if it you were typing directly into Octave.
 
 More information about debugging with Octave can be found
-[here](https://www.gnu.org/software/octave/doc/v4.0.0/Debugging.html).
+[here](https://octave.org/doc/v5.1.0/Debugging.html).
 
 
 ## Using Octave Debugger


### PR DESCRIPTION
Just a couple suggested changes to the README. One of the code sections is not actually formatted as code. And the link to the Octave Debugging doco is pointing to a rather old version 4.0.0; this updates it to point to the current 5.1.0 docs.